### PR TITLE
Make github scenarios work

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - centos-8
-          - centos-9
-          - debian-11
-          - ubuntu-20.04
-          - ubuntu-22.04
+          - centos-systemd:stream8
+          - centos-systemd:stream9
+          - debian-systemd:11
+          - ubuntu-systemd:20.04
+          - ubuntu-systemd:22.04
         python-version:
           - 3.8
         ansible-version:
@@ -48,4 +48,5 @@ jobs:
       - name: Test with molecule
         run: |
           cd ${{ github.repository }}
+          export docker_image_tag="${{ matrix.scenario }}"
           python3 -m molecule test

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,7 @@ lint: |
   yamllint . -c molecule/default/yaml-lint.yml
 platforms:
   - name: instance
-    image: "quay.io/gotmax23/ubuntu-systemd:focal"
+    image: "${docker_user:-quay.io/gotmax23}/${docker_image_tag:-ubuntu-systemd:focal}"
     # NOTE(logan): Uncomment user arg once upstream PR is released
     # https://github.com/metacloud/molecule/pull/1526
     # user: root


### PR DESCRIPTION
With previos commit CI was moved to gihub actions. However in fact, different
distros were not tested, as all docker containers were still ubuntu
focal. This is being fixed now.